### PR TITLE
support setting editor through opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ edit('hello world', function(err, result) {
 });
 ```
 
-Sometimes it can be useful to set an filename to help your editor to enable highlighting etc.
+Sometimes it can be useful to set an filename to help your editor to enable highlighting etc, or set another editor of choice.
 
 ``` js
 // we pass app.js as a filename to help with highlighting
-edit('var a = 42;', 'app.js', function(err, result) {
+// and $GIT_EDITOR as editor
+var opts = { filename: 'app.js', editor: process.env.GIT_EDITOR };
+edit('var a = 42;', opts, function(err, result) {
 	console.log(result);
 })
 ```

--- a/index.js
+++ b/index.js
@@ -3,18 +3,19 @@ var os = require('os');
 var fs = require('fs');
 var path = require('path');
 
-var edit = function(str, filename, cb) {
-	if (typeof filename === 'function') return edit(str, null, filename);
-	if (!filename) filename = Date.now()+'';
+var edit = function(str, opts, cb) {
+	if (typeof opts === 'function') return edit(str, null, opts);
+	opts = opts || {};
+	if (!opts.filename) opts.filename = Date.now()+'';
 
-	filename = path.join(os.tmpDir(), filename);
-	fs.writeFile(filename, str, function(err) {
+	opts.filename = path.join(os.tmpDir(), opts.filename);
+	fs.writeFile(opts.filename, str, function(err) {
 		if (err) return cb(err);
-		editor(filename, function(code) {
+		editor(opts.filename, { editor: opts.editor }, function(code) {
 			if (code) return cb(new Error('non-zero exit code ('+code+')'));
-			fs.readFile(filename, 'utf-8', function(err, result) {
+			fs.readFile(opts.filename, 'utf-8', function(err, result) {
 				if (err) return cb(err);
-				fs.unlink(filename, function() {
+				fs.unlink(opts.filename, function() {
 					cb(null, result);
 				});
 			});


### PR DESCRIPTION
Hi!

I use this package in a git-related tool and I need to override some of the choices [editor](https://github.com/substack/node-editor) does to use `$GIT_EDITOR` if present.

I added support for passing editor to [editor](https://github.com/substack/node-editor) through `opts.editor`. I find this functionality generally useful and future-proof.

However, this is a major change as is. Maybe we should to treat string-valued `opts` as `opts.filename` (like the encoding param for `fs.readFile`) for backward compatibility.
