### PR TITLE
Replace call to deprecated os.tmpDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var edit = function(str, filename, cb) {
 	if (typeof filename === 'function') return edit(str, null, filename);
 	if (!filename) filename = Date.now()+'';
 
-	filename = path.join(os.tmpDir(), filename);
+	filename = path.join(os.tmpdir(), filename);
 	fs.writeFile(filename, str, function(err) {
 		if (err) return cb(err);
 		editor(filename, function(code) {


### PR DESCRIPTION
Hi!

Node 7 [deprecated] `os.tmpDir` in favour of `os.tmpdir`, and now master produces the following warning:

```
$ env EDITOR=true node -e 'require("./")("", out => {})'
(node:5874) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```

This PR simply replaces one with the other.

[deprecated]: https://github.com/nodejs/node/pull/6739

